### PR TITLE
Fix python_version format

### DIFF
--- a/alienvaultotx.json
+++ b/alienvaultotx.json
@@ -20,10 +20,7 @@
     "package_name": "phantom_alienvaultotx",
     "main_module": "alienvaultotx_connector.py",
     "min_phantom_version": "5.5.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud, API v1 otx.alienvault.com/api/v1/, March 31 2023"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)