### PR TITLE
fix: encode AlienVault OTX pulse identifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2019-2025 Splunk Inc.
+   Copyright (c) 2019-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: AlienVault OTX
-Copyright (c) 2019-2025 Splunk Inc.
+Copyright (c) 2019-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AlienVault OTX
 
-Publisher: Splunk \
-Connector Version: 2.3.4 \
-Product Vendor: AlienVault \
-Product Name: AlienVault OTX \
+Publisher: Splunk <br>
+Connector Version: 2.3.4 <br>
+Product Vendor: AlienVault <br>
+Product Name: AlienVault OTX <br>
 Minimum Product Version: 5.5.0
 
 This app integrates with an instance of AlienVault OTX to perform investigative actions
@@ -41,18 +41,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[domain reputation](#action-domain-reputation) - Queries for domain reputation information \
-[ip reputation](#action-ip-reputation) - Queries for IP reputation information \
-[file reputation](#action-file-reputation) - Queries for file reputation information \
-[url reputation](#action-url-reputation) - Queries for URL reputation information \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[domain reputation](#action-domain-reputation) - Queries for domain reputation information <br>
+[ip reputation](#action-ip-reputation) - Queries for IP reputation information <br>
+[file reputation](#action-file-reputation) - Queries for file reputation information <br>
+[url reputation](#action-url-reputation) - Queries for URL reputation information <br>
 [get pulses](#action-get-pulses) - Get the pulse of the provided pulse ID
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -67,7 +67,7 @@ No Output
 
 Queries for domain reputation information
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -276,7 +276,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries for IP reputation information
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 The valid response_type values for IPv4 are general, reputation, geo, malware, url_list, and passive_dns. For IPv6, http_scans is also considered a valid response_type along with the ones mentioned for IPv4.
@@ -486,7 +486,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries for file reputation information
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -999,7 +999,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries for URL reputation information
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -1172,7 +1172,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get the pulse of the provided pulse ID
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -1225,7 +1225,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alienvaultotx.json
+++ b/alienvaultotx.json
@@ -14,7 +14,7 @@
             "name": "Ionut Ciubotarasu"
         }
     ],
-    "license": "Copyright (c) 2019-2025 Splunk Inc.",
+    "license": "Copyright (c) 2019-2026 Splunk Inc.",
     "app_version": "2.3.4",
     "utctime_updated": "2025-08-01T20:27:51.956439Z",
     "package_name": "phantom_alienvaultotx",
@@ -7568,5 +7568,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/alienvaultotx_connector.py
+++ b/alienvaultotx_connector.py
@@ -16,6 +16,7 @@
 #
 import ipaddress
 import json
+from urllib.parse import quote
 
 import phantom.app as phantom
 import phantom.utils as utils
@@ -334,7 +335,7 @@ class AlienvaultOtxv2Connector(BaseConnector):
     def _handle_get_pulses(self, param, action_id):
         self.save_progress(f"In action handler for: {action_id}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        pulse_id = param[OTX_JSON_PULSE_ID]
+        pulse_id = quote(str(param[OTX_JSON_PULSE_ID]), safe="")
 
         # make rest call
         ret_val, response = self._make_rest_call(OTX_GET_PULSES_ENDPOINT.format(pulse_id), action_result)

--- a/alienvaultotx_connector.py
+++ b/alienvaultotx_connector.py
@@ -1,6 +1,6 @@
 # File: alienvaultotx_connector.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alienvaultotx_consts.py
+++ b/alienvaultotx_consts.py
@@ -1,6 +1,6 @@
 # File: alienvaultotx_consts.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alienvaultotx_view.py
+++ b/alienvaultotx_view.py
@@ -1,6 +1,6 @@
 # File: alienvaultotx_view.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/display_pulses.html
+++ b/display_pulses.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: display_pulses.html
-  Copyright (c) 2019-2025 Splunk Inc.
+  Copyright (c) 2019-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Remove beautifulsoup4 from requirements.txt
+* Encode pulse identifiers before inserting them into AlienVault OTX API paths.


### PR DESCRIPTION
### Bug Fixes

- Percent-encode pulse identifiers before inserting them into AlienVault OTX API paths.
- Refresh shared pre-commit hooks and generated connector metadata before the functional remediation.

Tracking: [PAPP-38007](https://splunk.atlassian.net/browse/PAPP-38007), [PSAAS-30904](https://splunk.atlassian.net/browse/PSAAS-30904).

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that no manual documentation change is required; this preserves the existing action and parameter while safely encoding its path segment.

### Testing

- `python3 -m py_compile alienvaultotx_connector.py alienvaultotx_consts.py alienvaultotx_view.py`
- `pre-commit run --all-files`

No connector-local unit-test scaffolding was added because this is a legacy BaseConnector app.

Written by Codex with AI assistance.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
