### PR TITLE
fix: constrain AlienVault OTX API path inputs

### DIFF
--- a/alienvaultotx_connector.py
+++ b/alienvaultotx_connector.py
@@ -16,6 +16,7 @@
 #
 import ipaddress
 import json
+import re
 from urllib.parse import quote
 
 import phantom.app as phantom
@@ -335,7 +336,10 @@ class AlienvaultOtxv2Connector(BaseConnector):
     def _handle_get_pulses(self, param, action_id):
         self.save_progress(f"In action handler for: {action_id}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        pulse_id = quote(str(param[OTX_JSON_PULSE_ID]), safe="")
+        pulse_id = str(param[OTX_JSON_PULSE_ID])
+        if not re.fullmatch(r"[0-9a-fA-F]{24}", pulse_id):
+            return action_result.set_status(phantom.APP_ERROR, "Invalid pulse_id: expected a 24-character hexadecimal identifier")
+        pulse_id = quote(pulse_id, safe="")
 
         # make rest call
         ret_val, response = self._make_rest_call(OTX_GET_PULSES_ENDPOINT.format(pulse_id), action_result)

--- a/alienvaultotx_connector.py
+++ b/alienvaultotx_connector.py
@@ -313,7 +313,7 @@ class AlienvaultOtxv2Connector(BaseConnector):
     def _handle_url_reputation(self, param, action_id):
         self.save_progress(f"In action handler for: {action_id}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        url = param[OTX_JSON_URL]
+        url = quote(str(param[OTX_JSON_URL]), safe="")
         response_type = param.get(OTX_JSON_RESPONSE_TYPE, OTX_JSON_DEFAULT_RESPONSE)
         ret_val = self._validate_response_type(action_result, response_type, OTX_RESPONSE_TYPE_DICT[action_id])
         if phantom.is_fail(ret_val):

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Validate pulse identifiers before constructing API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Validate pulse identifiers before constructing API paths.
+* Encode URL reputation inputs as path segments.


### PR DESCRIPTION
Written by Codex.

## Summary

- Require the documented 24-character hexadecimal format for OTX pulse IDs.
- Reject exact dot segments through that positive pulse-ID validation.
- Encode URL reputation indicators as single API path segments.

The earlier pulse quoting left literal periods unchanged, and the URL reputation action still interpolated its caller-controlled URL directly into an authenticated API path. These two commits close the residual path-construction gaps independently.

## Tracking

- [PAPP-38007](https://splunk.atlassian.net/browse/PAPP-38007)
- [PSAAS-30904](https://splunk.atlassian.net/browse/PSAAS-30904)
- [VULN-93629](https://splunk.atlassian.net/browse/VULN-93629)
- Follow-up to [#28](https://github.com/splunk-soar-connectors/alienvaultotx/pull/28)

## Verification

- `pre-commit run --all-files`
- Source compilation with Python 3.9

## Release impact

The pulse action now enforces the identifier format already represented by connector examples and containment metadata. Asset configuration is unchanged.

Merge strategy: merge commit only; do not squash.
